### PR TITLE
Fix lexicographic sorting bug

### DIFF
--- a/client/process.js
+++ b/client/process.js
@@ -5,6 +5,8 @@ const percentile = require('percentile')
 const files = fs.readdirSync('./output');
 const output = fs.createWriteStream('./results.csv');
 
+let allLines = [];
+
 for (const file of files) {
   const outputFile = fs.readFileSync(path.join('output', file), 'utf-8');
 
@@ -13,10 +15,12 @@ for (const file of files) {
 
     return {
       sender,
-      latency,
+      latency: Number(latency),
       sequence
     }
   });
+
+  allLines = allLines.concat(lines);
 
   const results = percentile([50, 90, 99, 99.9, 99.99], lines, line => line.latency)
     .map(o => o.latency)
@@ -24,5 +28,11 @@ for (const file of files) {
 
   output.write(`${file},${results}\n`)
 }
+
+const results = percentile([50, 90, 99, 99.9, 99.99], allLines, line => line.latency)
+  .map(o => o.latency)
+  .join(',');
+
+output.write(`all connections,${results}\n`)
 
 output.close();

--- a/client/profiler.js
+++ b/client/profiler.js
@@ -29,6 +29,8 @@ class Connection {
 
     const socket = await this.connect();
 
+    const start = Date.now()
+
     setInterval(() => {
       socket.send(JSON.stringify({
         timestamp: Date.now(),
@@ -40,7 +42,10 @@ class Connection {
     socket.on('message', (messageSerialized) => {
       const message = JSON.parse(messageSerialized);
       const latency = Date.now() - message.timestamp;
-      stream.write(`${message.id},${latency},${message.sequence}\n`);
+      if (latency > 800) {
+        console.log(`Spike! on ${this.#id} from ${message.id}: ${latency}`)
+      }
+      stream.write(`${message.id},${latency},${message.sequence},${(Date.now() - start)/1000}\n`);
     });
 
     socket.on('error', (err) => {


### PR DESCRIPTION
`latency` was being passed into `percentile` as a string, causing it to perform a lexicographic sort before taking the percentile of results.

I also found that having time since the start for each received message was useful.